### PR TITLE
fix: allow use on darwin_arm64

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/external" {
-  version     = "1.2.0"
-  constraints = "~> 1.2"
+  version     = "2.2.2"
+  constraints = ">= 2.2.0"
   hashes = [
-    "h1:jIFj6CgC748E2UkSiBCYwKAspDPDsSyd0MDuin+swho=",
-    "zh:02048f972a31ac87231dd548323ee214cf04944b289c5d9edde82ffbde5b8386",
-    "zh:06fcf617521916883c5e3cbfa533dded6725246123f18355576a07f40f2ae4b0",
-    "zh:325dbc165665b3bd31164168bb65bf1f364c4a463cc8a2f8e3639b9738d9b16e",
-    "zh:5cf47495ec9ec1953f2a94875b23a4f44ff810422f1e63b5ef849fe1138e7aa1",
-    "zh:6cb3e94f4e795892005328e9a3aa12415b03ce99d6b7c92b3122f4204bb0ee73",
-    "zh:6d731e12c616434886f007cad68d9313a178ddfb0360de84236fc5593f443c10",
-    "zh:9a269a735d9e0c3b1390e6319df46ee2d0afc057c32a899ffc885df78d012123",
-    "zh:a91b5d526011f5ee56461b1d7a9fcb230aab6c38c01facb73ecd98c5e958204e",
-    "zh:aa5f19ba3040a4a10f4c5290d075544d7cdad4b90fb10a469a1d40cbaf4607e5",
-    "zh:c986125fda03444ac8c964e999c48db450b452e0b4edf4542e3bee97ca951cbd",
-    "zh:fddff8f179925c1c76e58302ddcbead9474ea52c6e8141f5ba73bb137ca2ebc5",
-    "zh:fe2ef9dcc45291d0582bbf1f5936522682cf2e03a3811a8e6968f1ba14d91f25",
+    "h1:BKQ5f5ijzeyBSnUr+j0wUi+bYv6KBQVQNDXNRVEcfJE=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
   ]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 1.2"
+      version = ">= 2.2.0"
     }
   }
 }


### PR DESCRIPTION
Using terraform-terraform-errorcheck module on Apple M1 platforms throws an error during `terraform init`:

```
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/hashicorp/external v1.2.0 does not have a package available for your current platform, darwin_arm64.
```
By migrating to the latest version of `hashicorp/external` this is resolved.